### PR TITLE
Add support to peer deps for Ract v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "peerDependencies": {
     "html5-device-mockups": "^3.2.1",
     "prop-types": "^15.5.4",
-    "react": "^15.0.0 || ^16.0.0",
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
     "react-dom": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "html5-device-mockups": "^3.2.1",
     "prop-types": "^15.5.4",
     "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "@svgr/rollup": "^2.4.1",


### PR DESCRIPTION
Could add React v18^, as well, but I don't know many people using it consistently yet, so I think React17 will work fine.